### PR TITLE
Fix green button hardcoding and add material design stylesheet

### DIFF
--- a/rare/components/tabs/cloud_saves/sync_widget.py
+++ b/rare/components/tabs/cloud_saves/sync_widget.py
@@ -116,9 +116,7 @@ class SyncWidget(QGroupBox):
         elif self.res == SaveGameStatus.REMOTE_NEWER:
             status = self.tr("Cloud save is newer")
             self.download_button = QPushButton(self.tr("Download Cloud saves"))
-            self.download_button.setStyleSheet("""
-                           QPushButton{ background-color: lime}
-                       """)
+            self.download_button.setObjectName("success")
             self.upload_button = QPushButton(self.tr("Upload Saves"))
             self.logger.info(f'Cloud save for "{igame.title}" is newer:')
             self.logger.info(f'- Cloud save date: {dt_remote.strftime("%Y-%m-%d %H:%M:%S")}')
@@ -132,9 +130,7 @@ class SyncWidget(QGroupBox):
         elif self.res == SaveGameStatus.LOCAL_NEWER:
             status = self.tr("Local save is newer")
             self.upload_button = QPushButton(self.tr("Upload saves"))
-            self.upload_button.setStyleSheet("""
-                           QPushButton{ background-color: lime}
-                       """)
+            self.download_button.setObjectName("success")
             self.download_button = QPushButton(self.tr("Download saves"))
             self.logger.info(f'Local save for "{igame.title}" is newer')
             if dt_remote:

--- a/rare/styles/qss/RareMaterial.qss
+++ b/rare/styles/qss/RareMaterial.qss
@@ -1,0 +1,401 @@
+/*
+Modified from:
+
+Material Dark Style Sheet for QT Applications
+Author: Jaime A. Quiroga P.
+Inspired on https://github.com/jxfwinter/qt-material-stylesheet
+Company: GTRONICK
+Available at: https://github.com/GTRONICK/QSS/blob/master/MaterialDark.qss
+*/
+QMainWindow {
+	background-color:#1e1d23;
+}
+QDialog {
+	background-color:#1e1d23;
+}
+QColorDialog {
+	background-color:#1e1d23;
+}
+QTextEdit {
+	background-color:#1e1d23;
+	color: #a9b7c6;
+}
+QPlainTextEdit {
+	selection-background-color:#007b50;
+	background-color:#1e1d23;
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: transparent;
+	border-width: 1px;
+	color: #a9b7c6;
+}
+QPushButton{
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: transparent;
+	border-width: 1px;
+	border-style: solid;
+	color: #a9b7c6;
+	padding: 2px;
+	background-color: #1e1d23;
+}
+QPushButton::default{
+	border-style: inset;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #04b97f;
+	border-width: 1px;
+	color: #a9b7c6;
+	padding: 2px;
+	background-color: #1e1d23;
+}
+QPushButton#success{
+	background-color: #04b97f;
+	color: black;
+}
+QToolButton {
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #04b97f;
+	border-bottom-width: 1px;
+	border-style: solid;
+	color: #a9b7c6;
+	padding: 2px;
+	background-color: #1e1d23;
+}
+QToolButton:hover{
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #37efba;
+	border-bottom-width: 2px;
+	border-style: solid;
+	color: #FFFFFF;
+	padding-bottom: 1px;
+	background-color: #1e1d23;
+}
+QPushButton:hover{
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #37efba;
+	border-bottom-width: 1px;
+	border-style: solid;
+	color: #FFFFFF;
+	padding-bottom: 2px;
+	background-color: #1e1d23;
+}
+QPushButton:pressed{
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #37efba;
+	border-bottom-width: 2px;
+	border-style: solid;
+	color: #37efba;
+	padding-bottom: 1px;
+	background-color: #1e1d23;
+}
+QPushButton#success:hover{
+	border-bottom-color: #808086;
+}
+QPushButton#success:pressed{
+	border-bottom-color: #a9b7c6;
+}
+QPushButton:disabled{
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #808086;
+	border-bottom-width: 2px;
+	border-style: solid;
+	color: #808086;
+	padding-bottom: 1px;
+	background-color: #1e1d23;
+}
+QLineEdit {
+	border-width: 1px; border-radius: 4px;
+	border-color: rgb(58, 58, 58);
+	border-style: inset;
+	padding: 0 8px;
+	color: #a9b7c6;
+	background:#1e1d23;
+	selection-background-color:#007b50;
+	selection-color: #FFFFFF;
+}
+QLabel {
+	color: #a9b7c6;
+}
+QLCDNumber {
+	color: #37e6b4;
+}
+QProgressBar {
+	text-align: center;
+	color: rgb(240, 240, 240);
+	border-width: 1px;
+	border-radius: 10px;
+	border-color: rgb(58, 58, 58);
+	border-style: inset;
+	background-color:#1e1d23;
+}
+QProgressBar::chunk {
+	background-color: #04b97f;
+	border-radius: 5px;
+}
+QMenuBar {
+	background-color: #1e1d23;
+}
+QMenuBar::item {
+	color: #a9b7c6;
+  	spacing: 3px;
+  	padding: 1px 4px;
+  	background: #1e1d23;
+}
+
+QMenuBar::item:selected {
+  	background:#1e1d23;
+	color: #FFFFFF;
+}
+QMenu::item:selected {
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: #04b97f;
+	border-bottom-color: transparent;
+	border-left-width: 2px;
+	color: #FFFFFF;
+	padding-left:15px;
+	padding-top:4px;
+	padding-bottom:4px;
+	padding-right:7px;
+	background-color: #1e1d23;
+}
+QMenu::item {
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: transparent;
+	border-bottom-width: 1px;
+	border-style: solid;
+	color: #a9b7c6;
+	padding-left:17px;
+	padding-top:4px;
+	padding-bottom:4px;
+	padding-right:7px;
+	background-color: #1e1d23;
+}
+QMenu{
+	background-color:#1e1d23;
+}
+QTabWidget {
+	color:rgb(0,0,0);
+	background-color:#1e1d23;
+}
+QTabWidget::pane {
+		border-color: rgb(77,77,77);
+		background-color:#1e1d23;
+		border-style: solid;
+		border-width: 1px;
+    	border-radius: 6px;
+}
+QTabBar::tab {
+	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: transparent;
+	border-bottom-width: 1px;
+	border-style: solid;
+	color: #808086;
+	padding: 3px;
+	margin-left:3px;
+	background-color: #1e1d23;
+}
+QTabBar::tab:selected, QTabBar::tab:last:selected, QTabBar::tab:hover {
+  	border-style: solid;
+	border-top-color: transparent;
+	border-right-color: transparent;
+	border-left-color: transparent;
+	border-bottom-color: #04b97f;
+	border-bottom-width: 2px;
+	border-style: solid;
+	color: #FFFFFF;
+	padding-left: 3px;
+	padding-bottom: 2px;
+	margin-left:3px;
+	background-color: #1e1d23;
+}
+
+QCheckBox {
+	color: #a9b7c6;
+	padding: 2px;
+}
+QCheckBox:disabled {
+	color: #808086;
+	padding: 2px;
+}
+
+QCheckBox:hover {
+	border-radius:4px;
+	border-style:solid;
+	padding-left: 1px;
+	padding-right: 1px;
+	padding-bottom: 1px;
+	padding-top: 1px;
+	border-width:1px;
+	border-color: rgb(87, 97, 106);
+	background-color:#1e1d23;
+}
+QCheckBox::indicator:checked {
+
+	height: 10px;
+	width: 10px;
+	border-style:solid;
+	border-width: 1px;
+	border-color: #04b97f;
+	color: #a9b7c6;
+	background-color: #04b97f;
+}
+QCheckBox::indicator:unchecked {
+
+	height: 10px;
+	width: 10px;
+	border-style:solid;
+	border-width: 1px;
+	border-color: #04b97f;
+	color: #a9b7c6;
+	background-color: transparent;
+}
+QRadioButton {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+	padding: 1px;
+}
+QRadioButton::indicator:checked {
+	height: 10px;
+	width: 10px;
+	border-style:solid;
+	border-radius:5px;
+	border-width: 1px;
+	border-color: #04b97f;
+	color: #a9b7c6;
+	background-color: #04b97f;
+}
+QRadioButton::indicator:!checked {
+	height: 10px;
+	width: 10px;
+	border-style:solid;
+	border-radius:5px;
+	border-width: 1px;
+	border-color: #04b97f;
+	color: #a9b7c6;
+	background-color: transparent;
+}
+QStatusBar {
+	color:#027f7f;
+}
+QSpinBox {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QDoubleSpinBox {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QTimeEdit {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QDateTimeEdit {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QDateEdit {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QComboBox {
+	color: #a9b7c6;
+	background: #1e1d23;
+}
+QComboBox:editable {
+	background: #1e1d23;
+	color: #a9b7c6;
+	selection-background-color: #1e1d23;
+}
+QComboBox QAbstractItemView {
+	color: #a9b7c6;
+	background: #1e1d23;
+	selection-color: #FFFFFF;
+	selection-background-color: #1e1d23;
+}
+QComboBox:!editable:on, QComboBox::drop-down:editable:on {
+	color: #a9b7c6;
+	background: #1e1d23;
+}
+QFontComboBox {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QToolBox {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QToolBox::tab {
+	color: #a9b7c6;
+	background-color: #1e1d23;
+}
+QToolBox::tab:selected {
+	color: #FFFFFF;
+	background-color: #1e1d23;
+}
+QScrollArea {
+	color: #FFFFFF;
+	background-color: #1e1d23;
+}
+QSlider::groove:horizontal {
+	height: 5px;
+	background: #04b97f;
+}
+QSlider::groove:vertical {
+	width: 5px;
+	background: #04b97f;
+}
+QSlider::handle:horizontal {
+	background: qlineargradient(x1:0, y1:0, x2:1, y2:1, stop:0 #b4b4b4, stop:1 #8f8f8f);
+	border: 1px solid #5c5c5c;
+	width: 14px;
+	margin: -5px 0;
+	border-radius: 7px;
+}
+QSlider::handle:vertical {
+	background: qlineargradient(x1:1, y1:1, x2:0, y2:0, stop:0 #b4b4b4, stop:1 #8f8f8f);
+	border: 1px solid #5c5c5c;
+	height: 14px;
+	margin: 0 -5px;
+	border-radius: 7px;
+}
+QSlider::add-page:horizontal {
+    background: white;
+}
+QSlider::add-page:vertical {
+    background: white;
+}
+QSlider::sub-page:horizontal {
+    background: #04b97f;
+}
+QSlider::sub-page:vertical {
+    background: #04b97f;
+}

--- a/rare/styles/qss/RareStyle.qss
+++ b/rare/styles/qss/RareStyle.qss
@@ -170,6 +170,10 @@ QPushButton:hover#menu_button {
     background-color: #334;
 }
 
+QPushButton#success{
+    background-color: lime;
+}
+
 QRadioButton {
     background-color: none;
     border-radius: 50%;


### PR DESCRIPTION
This is a pretty simple PR. I fixed the hardcoding of the lime color on the "Download Cloud saves" button by giving it an id of `success` which can be accessed in the stylesheet via `QPushButton#success`. I also added a Material Design stylesheet modified from the one [here](https://github.com/GTRONICK/QSS/blob/master/MaterialDark.qss). I think it looks pretty nice, and feel free to ask any questions.