### PR TITLE
RareStyle: Fix QGroupBox title for Linux and Windows

### DIFF
--- a/rare/resources/stylesheets/RareStyle/stylesheet.qss
+++ b/rare/resources/stylesheets/RareStyle/stylesheet.qss
@@ -1,14 +1,16 @@
 /*
 */
 
-* { background-color: #202225; }
-* { color: #eeeeee; }
-* { border-color: #483d8b; }
+* {
+    color: #eeeeee;
+    border-color: #483d8b;
+    background-color: #202225;
+}
 *:disabled,
 *::drop-down:disabled {
     color: #43474d;
     border-color: #43474d;
-    background-color: #202225;
+    background-color: transparent;
 }
 
 QLabel {
@@ -392,18 +394,35 @@ QRadioButton::indicator:checked:disabled {
 QGroupBox,
 QGroupBox#group,
 QGroupBox#settings_widget {
+    font-weight: bold;
+    margin-top: 1ex;
+    /* margin-left: 0.5em; /* Offset to the left */
     border-width: 1px;
     border-style: solid;
     border-radius: 4px;
-    font-size: 11px;
-    font-weight: bold;
-    margin-top: 3ex;
-    padding: 1px;
+    padding-top: 3ex;
 }
 QGroupBox#game_widget_icon {
+    margin: 2px;
     border-width: 0px;
     padding: 0px;
-    margin: 2px;
+}
+QGroupBox::title {
+    /* background: qlineargradient(x1: -2, y1: 0, x2: 1, y2: 1,
+			    stop: 0 #483d8b, stop: 1 #202225); /* stop: 0 #28224D */
+    subcontrol-origin: border;
+    subcontrol-position: top left; /* position at the top left */
+    border-width: 1px;
+    border-style: solid;
+    border-top-left-radius: 4px;
+    border-bottom-right-radius: 4px;
+    border-bottom-color: #483d8b;
+    border-right-color: #483d8b;
+    padding: 1px;
+}
+QGroupBox::title:disabled {
+    border-bottom-color: #43474d;
+    border-right-color: #43474d;
 }
 
 QSizeGrip {

--- a/rare/resources/stylesheets/RareStyle/stylesheet.qss
+++ b/rare/resources/stylesheets/RareStyle/stylesheet.qss
@@ -7,13 +7,14 @@
     background-color: #202225;
 }
 *:disabled,
-*::drop-down:disabled {
+*:editable:disabled {
     color: #43474d;
     border-color: #43474d;
-    background-color: transparent;
+    background-color: #202225;
 }
 
-QLabel {
+QLabel,
+QLabel:disabled {
     border-width: 0px;
     background-color: transparent;
     padding: 0px;
@@ -80,10 +81,10 @@ QSpinBox,
 QDoubleSpinBox,
 QProgressBar,
 QPushButton {
-    height: 17px;
+    height: 3ex;
 }
 QToolButton {
-    height: 14px;
+    height: 2.5ex;
 }
 QFrame[frameShape="6"] {
     border-radius: 4px;
@@ -93,7 +94,13 @@ QScrollArea[noBorder="1"] {
     border-color: transparent;
 }
 QComboBox {
-    background-color: #3c3f41;
+    background-color: rgba(67, 71, 77, 55%);
+}
+QComboBox:disabled {
+    background-color: rgba(67, 71, 77, 25%);
+}
+QComboBox:!editable:hover {
+    background-color: #222233;
 }
 *::item:selected,
 QComboBox QAbstractItemView {
@@ -110,12 +117,18 @@ QComboBox QAbstractItemView {
     border-top-left-radius: 0px;
     border-bottom-left-radius: 0px;
 }
+*::drop-down:disabled,
+*::drop-down:editable:disabled,
+*::up-button:disabled,
+*::down-button:disabled {
+    border-color: #43474d;
+    background-color: transparent;
+}
 *::drop-down {
     subcontrol-position: top right;
     border-color: #483d8b;
     border-left-color: #5246a0; /* #483d8b lighter */
 }
-
 *::drop-down:editable,
 *::up-button,
 *::down-button {
@@ -244,7 +257,11 @@ QTableView::item:selected {
 
 QPushButton,
 QToolButton {
-    background-color: #3c3f41;
+    background-color: rgba(67, 71, 77, 55%);
+}
+QPushButton:disabled,
+QToolButton:disabled {
+    background-color: rgba(67, 71, 77, 25%);
 }
 QPushButton:hover,
 QToolButton:hover,
@@ -408,21 +425,21 @@ QGroupBox#game_widget_icon {
     padding: 0px;
 }
 QGroupBox::title {
-    /* background: qlineargradient(x1: -2, y1: 0, x2: 1, y2: 1,
-			    stop: 0 #483d8b, stop: 1 #202225); /* stop: 0 #28224D */
     subcontrol-origin: border;
     subcontrol-position: top left; /* position at the top left */
     border-width: 1px;
     border-style: solid;
     border-top-left-radius: 4px;
     border-bottom-right-radius: 4px;
-    border-bottom-color: #483d8b;
-    border-right-color: #483d8b;
+    border-color: #483d8b;
     padding: 1px;
+    /* background: qlineargradient(x1: -2, y1: 0, x2: 1, y2: 1,
+			    stop: 0 #483d8b, stop: 1 #202225); /* stop: 0 #28224D */
+    background-color: rgba(72, 61, 139, 25%);
 }
 QGroupBox::title:disabled {
-    border-bottom-color: #43474d;
-    border-right-color: #43474d;
+    border-color: #43474d;
+    background-color: rgba(67, 71, 77, 25%);
 }
 
 QSizeGrip {


### PR DESCRIPTION
Specify widget size in ex, not px.
Make QComboBox look like a button, and editable QComboBox like a QLineEdit.
Make disabled widgets more distinguishable.