### PR TITLE
Remove leftover + from f-string refactor which breaks Proton settings saving

### DIFF
--- a/rare/components/tabs/games/game_info/game_settings.py
+++ b/rare/components/tabs/games/game_info/game_settings.py
@@ -305,7 +305,7 @@ class GameSettings(QWidget, Ui_GameSettings):
 
     def proton_prefix_save(self, text: str):
         self.core.lgd.config.set(
-             + f"{self.game.app_name}.env", "STEAM_COMPAT_DATA_PATH", text
+            f"{self.game.app_name}.env", "STEAM_COMPAT_DATA_PATH", text
         )
         self.core.lgd.save_config()
 


### PR DESCRIPTION
This removes a leftover `+`, which made the function `proton_prefix_save` burst into flames as a lone `+` has no meaning on a `str`.