### PR TITLE
Implement global objects as functions that return a single instance

### DIFF
--- a/rare/app.py
+++ b/rare/app.py
@@ -8,7 +8,7 @@ import time
 import traceback
 from argparse import Namespace
 
-from PyQt5.QtCore import QThreadPool, QSettings, QTranslator
+from PyQt5.QtCore import Qt, QThreadPool, QSettings, QTranslator
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QApplication, QSystemTrayIcon, QMessageBox
 from requests import HTTPError
@@ -60,6 +60,9 @@ class App(QApplication):
         self.args = ArgumentsSingleton(args)  # add some options
         self.window_launched = False
         self.setQuitOnLastWindowClosed(False)
+
+        if hasattr(Qt, 'AA_UseHighDpiPixmaps'):
+            self.setAttribute(Qt.AA_UseHighDpiPixmaps)
 
         # init Legendary
         try:

--- a/rare/components/dialogs/login/__init__.py
+++ b/rare/components/dialogs/login/__init__.py
@@ -5,7 +5,7 @@ from PyQt5.QtCore import Qt
 from PyQt5.QtWidgets import QSizePolicy, QLayout, QDialog, QMessageBox
 
 from legendary.core import LegendaryCore
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, ArgumentsSingleton
 from rare.components.dialogs.login.browser_login import BrowserLogin
 from rare.components.dialogs.login.import_login import ImportLogin
 from rare.ui.components.dialogs.login.login_dialog import Ui_LoginDialog
@@ -32,6 +32,7 @@ class LoginDialog(QDialog, Ui_LoginDialog):
         self.setWindowModality(Qt.WindowModal)
 
         self.core = core
+        self.args = ArgumentsSingleton()
 
         self.browser_page = BrowserLogin(self.core, self.login_stack)
         self.login_stack.insertWidget(self.pages.browser, self.browser_page)
@@ -85,7 +86,7 @@ class LoginDialog(QDialog, Ui_LoginDialog):
             self.import_page.do_login()
 
     def login(self):
-        if shared.args.test_start:
+        if self.args.test_start:
             return False
         self.exec_()
         return self.logged_in

--- a/rare/components/main_window.py
+++ b/rare/components/main_window.py
@@ -5,7 +5,7 @@ from PyQt5.QtCore import Qt, QSettings, QTimer, QSize
 from PyQt5.QtGui import QCloseEvent, QCursor
 from PyQt5.QtWidgets import QMainWindow, QApplication, QStatusBar
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton
 from rare.components.tabs import TabWidget
 from rare.utils.paths import data_dir
 
@@ -16,11 +16,11 @@ class MainWindow(QMainWindow):
     def __init__(self):
         super(MainWindow, self).__init__()
         self.setAttribute(Qt.WA_DeleteOnClose)
-        self.settings = QSettings()
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
 
-        self.signals = shared.signals
-        self.offline = shared.args.offline
+        self.settings = QSettings()
 
         self.setWindowTitle("Rare - GUI for legendary")
         self.tab_widget = TabWidget(self)
@@ -35,7 +35,7 @@ class MainWindow(QMainWindow):
 
         self.resize(width, height)
 
-        if not shared.args.offline:
+        if not self.args.offline:
             try:
                 from rare.utils.rpc import DiscordRPC
                 self.rpc = DiscordRPC()
@@ -46,7 +46,7 @@ class MainWindow(QMainWindow):
         self.timer.timeout.connect(self.timer_finished)
         self.timer.start(1000)
 
-    def show_window_centralized(self):
+    def show_window_centered(self):
         self.show()
         # get the margins of the decorated window
         margins = self.windowHandle().frameMargins()
@@ -78,7 +78,7 @@ class MainWindow(QMainWindow):
                     i.app_name for i in self.tab_widget.games_tab.game_list
                 ] and self.core.is_installed(game):
                     self.tab_widget.games_tab.game_utils.prepare_launch(
-                        game, offline=shared.args.offline
+                        game, offline=self.args.offline
                     )
                 else:
                     logger.info(f"Could not find {game} in Games")
@@ -95,7 +95,7 @@ class MainWindow(QMainWindow):
             self.hide()
             e.ignore()
             return
-        elif self.offline:
+        elif self.args.offline:
             pass
         self.signals.exit_app.emit(0)
         e.ignore()

--- a/rare/components/tabs/__init__.py
+++ b/rare/components/tabs/__init__.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import QSize
 from PyQt5.QtWidgets import QMenu, QTabWidget, QWidget, QWidgetAction, QShortcut
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton
 from rare.components.tabs.account import MiniWidget
 from rare.components.tabs.downloads import DownloadsTab
 from rare.components.tabs.games import GamesTab
@@ -15,9 +15,10 @@ from rare.utils.utils import icon
 class TabWidget(QTabWidget):
     def __init__(self, parent):
         super(TabWidget, self).__init__(parent=parent)
-        disabled_tab = 3 if not shared.args.offline else 1
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
+        disabled_tab = 3 if not self.args.offline else 1
         self.setTabBar(MainTabBar(disabled_tab))
         # lk: Figure out why this adds a white line at the top
         # lk: despite setting qproperty-drawBase to 0 in the stylesheet
@@ -26,7 +27,7 @@ class TabWidget(QTabWidget):
         self.games_tab = GamesTab()
         self.addTab(self.games_tab, self.tr("Games"))
 
-        if not shared.args.offline:
+        if not self.args.offline:
             # updates = self.games_tab.default_widget.game_list.updates
             self.downloadTab = DownloadsTab(self.games_tab.updates)
             self.addTab(
@@ -42,7 +43,7 @@ class TabWidget(QTabWidget):
             self.addTab(self.store, self.tr("Store (Beta)"))
 
         self.settings = SettingsTab(self)
-        if shared.args.debug:
+        if self.args.debug:
             self.settings.addTab(DebugSettings(), "Debug")
 
         # Space Tab
@@ -102,7 +103,7 @@ class TabWidget(QTabWidget):
         if tab_num == 0:
             self.games_tab.layout().setCurrentIndex(0)
 
-        if not shared.args.offline and tab_num == 2:
+        if not self.args.offline and tab_num == 2:
             self.store.load()
 
     def resizeEvent(self, event):

--- a/rare/components/tabs/account/__init__.py
+++ b/rare/components/tabs/account/__init__.py
@@ -2,15 +2,15 @@ import webbrowser
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QMessageBox, QLabel, QPushButton
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton
 
 
 class MiniWidget(QWidget):
     def __init__(self):
         super(MiniWidget, self).__init__()
         self.layout = QVBoxLayout()
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
         self.layout.addWidget(QLabel("Account"))
         username = self.core.lgd.userdata.get("display_name")
         if not username:

--- a/rare/components/tabs/downloads/__init__.py
+++ b/rare/components/tabs/downloads/__init__.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import (
 from legendary.core import LegendaryCore
 from legendary.models.downloading import UIUpdate
 from legendary.models.game import Game, InstalledGame
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton
 from rare.components.dialogs.install_dialog import InstallDialog
 from rare.components.tabs.downloads.dl_queue_widget import DlQueueWidget, DlWidget
 from rare.components.tabs.downloads.download_thread import DownloadThread
@@ -34,10 +34,10 @@ class DownloadsTab(QWidget, Ui_DownloadsTab):
     def __init__(self, updates: list):
         super(DownloadsTab, self).__init__()
         self.setupUi(self)
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
         self.active_game: Game = None
         self.analysis = None
-        self.signals = shared.signals
 
         self.kill_button.clicked.connect(self.stop_download)
 
@@ -68,7 +68,7 @@ class DownloadsTab(QWidget, Ui_DownloadsTab):
         self.signals.add_download.connect(
             lambda app_name: self.add_update(self.core.get_installed_game(app_name))
         )
-        shared.signals.game_uninstalled.connect(self.game_uninstalled)
+        self.signals.game_uninstalled.connect(self.game_uninstalled)
 
         self.reset_infos()
 

--- a/rare/components/tabs/downloads/download_thread.py
+++ b/rare/components/tabs/downloads/download_thread.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import QMessageBox
 
 from legendary.core import LegendaryCore
 from legendary.models.downloading import UIUpdate, WriterTask
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton
 from rare.utils.models import InstallQueueItemModel
 from rare.utils.utils import create_desktop_link
 
@@ -27,6 +27,7 @@ class DownloadThread(QThread):
     def __init__(self, core: LegendaryCore, queue_item: InstallQueueItemModel):
         super(DownloadThread, self).__init__()
         self.core = core
+        self.signals = GlobalSignalsSingleton()
         self.dlm = queue_item.download.dlmanager
         self.no_install = queue_item.options.no_install
         self.status_q = queue_item.status_q
@@ -147,7 +148,7 @@ class DownloadThread(QThread):
             game = self.core.get_game(self.igame.app_name)
 
             if self.queue_item.options.overlay:
-                shared.signals.overlay_installation_finished.emit()
+                self.signals.overlay_installation_finished.emit()
                 self.core.finish_overlay_install(self.igame)
                 self.status.emit("finish")
                 return

--- a/rare/components/tabs/games/__init__.py
+++ b/rare/components/tabs/games/__init__.py
@@ -4,7 +4,7 @@ from typing import Tuple, Dict, Union, List
 from PyQt5.QtCore import QSettings, QObjectCleanupHandler
 from PyQt5.QtWidgets import QStackedWidget, QVBoxLayout, QWidget
 
-import rare.shared as shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton, ApiResultsSingleton
 from legendary.models.game import InstalledGame, Game
 from rare.ui.components.tabs.games.games_tab import Ui_GamesTab
 from rare.utils.extra_widgets import FlowLayout
@@ -37,15 +37,17 @@ class GamesTab(QStackedWidget, Ui_GamesTab):
     def __init__(self, parent=None):
         super(GamesTab, self).__init__(parent=parent)
         self.setupUi(self)
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
+        self.api_results = ApiResultsSingleton()
         self.settings = QSettings()
 
-        self.game_list: List[Game] = shared.api_results.game_list
-        self.dlcs = shared.api_results.dlcs
-        self.bit32 = shared.api_results.bit32_games
-        self.mac_games = shared.api_results.mac_games
-        self.no_assets = shared.api_results.no_asset_games
+        self.game_list: List[Game] = self.api_results.game_list
+        self.dlcs = self.api_results.dlcs
+        self.bit32 = self.api_results.bit32_games
+        self.mac_games = self.api_results.mac_games
+        self.no_assets = self.api_results.no_asset_games
 
         self.game_utils = GameUtils(parent=self)
 
@@ -75,7 +77,7 @@ class GamesTab(QStackedWidget, Ui_GamesTab):
         self.head_bar.import_game.clicked.connect(lambda: self.setCurrentIndex(2))
 
         self.no_asset_names = []
-        if not shared.args.offline:
+        if not self.args.offline:
             for game in self.no_assets:
                 self.no_asset_names.append(game.app_name)
         else:

--- a/rare/components/tabs/games/game_info/__init__.py
+++ b/rare/components/tabs/games/game_info/__init__.py
@@ -1,7 +1,7 @@
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QKeyEvent
 
-import rare.shared as shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton
 from rare.utils.extra_widgets import SideTabWidget
 from .game_dlc import GameDlc
 from .game_info import GameInfo
@@ -12,8 +12,8 @@ from ..game_utils import GameUtils
 class GameInfoTabs(SideTabWidget):
     def __init__(self, dlcs: dict, game_utils: GameUtils, parent=None):
         super(GameInfoTabs, self).__init__(show_back=True, parent=parent)
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
 
         self.info = GameInfo(self, game_utils)
         self.addTab(self.info, self.tr("Information"))

--- a/rare/components/tabs/games/game_info/game_dlc.py
+++ b/rare/components/tabs/games/game_info/game_dlc.py
@@ -3,7 +3,7 @@ from PyQt5.QtGui import QPixmap, QResizeEvent
 from PyQt5.QtWidgets import QFrame, QWidget, QMessageBox
 
 from legendary.models.game import Game
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton
 from rare.components.tabs.games.game_utils import GameUtils
 from rare.ui.components.tabs.games.game_info.game_dlc import Ui_GameDlc
 from rare.ui.components.tabs.games.game_info.game_dlc_widget import Ui_GameDlcWidget
@@ -18,12 +18,13 @@ class GameDlc(QWidget, Ui_GameDlc):
     def __init__(self, dlcs: dict, game_utils: GameUtils, parent=None):
         super(GameDlc, self).__init__(parent=parent)
         self.setupUi(self)
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+
         self.game_utils = game_utils
 
         self.available_dlc_scroll.setProperty("noBorder", 1)
         self.installed_dlc_scroll.setProperty("noBorder", 1)
-        self.signals = shared.signals
-        self.core = shared.core
 
         self.dlcs = dlcs
         self.installed_dlc_widgets = list()

--- a/rare/components/tabs/games/game_info/game_info.py
+++ b/rare/components/tabs/games/game_info/game_info.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import pyqtSignal, QThreadPool
 from PyQt5.QtWidgets import QWidget, QMessageBox
 
 from legendary.models.game import Game, InstalledGame
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton
 from rare.ui.components.tabs.games.game_info.game_info import Ui_GameInfo
 from rare.utils.legendary_utils import VerifyWorker
 from rare.utils.models import InstallOptionsModel
@@ -26,8 +26,9 @@ class GameInfo(QWidget, Ui_GameInfo):
     def __init__(self, parent, game_utils):
         super(GameInfo, self).__init__(parent=parent)
         self.setupUi(self)
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
         self.game_utils = game_utils
 
         if platform.system() == "Windows":
@@ -47,7 +48,7 @@ class GameInfo(QWidget, Ui_GameInfo):
 
         self.verify_pool = QThreadPool()
         self.verify_pool.setMaxThreadCount(2)
-        if shared.args.offline:
+        if self.args.offline:
             self.repair_button.setDisabled(True)
         else:
             self.repair_button.clicked.connect(self.repair)
@@ -175,7 +176,7 @@ class GameInfo(QWidget, Ui_GameInfo):
         else:
             self.uninstall_button.setDisabled(False)
             self.verify_button.setDisabled(False)
-            if not shared.args.offline:
+            if not self.args.offline:
                 self.repair_button.setDisabled(False)
             self.game_actions_stack.setCurrentIndex(0)
 

--- a/rare/components/tabs/games/game_info/uninstalled_info.py
+++ b/rare/components/tabs/games/game_info/uninstalled_info.py
@@ -4,7 +4,7 @@ from PyQt5.QtCore import Qt, QThreadPool
 from PyQt5.QtGui import QKeyEvent
 from PyQt5.QtWidgets import QWidget, QTreeView
 
-import rare.shared as shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton, ApiResultsSingleton
 from legendary.models.game import Game
 from rare.ui.components.tabs.games.game_info.game_info import Ui_GameInfo
 from rare.utils.extra_widgets import SideTabWidget
@@ -17,11 +17,12 @@ from rare.utils.utils import get_pixmap
 class UninstalledInfoTabs(SideTabWidget):
     def __init__(self, parent=None):
         super(UninstalledInfoTabs, self).__init__(show_back=True, parent=parent)
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
 
         self.info = UninstalledInfo()
-        self.info.install_button.setDisabled(shared.args.offline)
+        self.info.install_button.setDisabled(self.args.offline)
         self.addTab(self.info, self.tr("Information"))
 
         self.view = QTreeView()
@@ -55,8 +56,9 @@ class UninstalledInfo(QWidget, Ui_GameInfo):
     def __init__(self, parent=None):
         super(UninstalledInfo, self).__init__(parent=parent)
         self.setupUi(self)
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.api_results = ApiResultsSingleton()
         self.install_button.clicked.connect(self.install_game)
         if platform.system() != "Windows":
             self.steam_worker = SteamWorker(self.core)
@@ -83,9 +85,9 @@ class UninstalledInfo(QWidget, Ui_GameInfo):
         self.game = game
         self.game_title.setText(f"<h2>{self.game.app_title}</h2>")
         available_platforms = ["Windows"]
-        if self.game.app_name in shared.api_results.bit32_games:
+        if self.game.app_name in self.api_results.bit32_games:
             available_platforms.append("32 Bit")
-        if self.game.app_name in shared.api_results.mac_games:
+        if self.game.app_name in self.api_results.mac_games:
             available_platforms.append("macOS")
         self.platform.setText(", ".join(available_platforms))
 

--- a/rare/components/tabs/games/game_utils.py
+++ b/rare/components/tabs/games/game_utils.py
@@ -10,7 +10,7 @@ from PyQt5.QtCore import QObject, QSettings, QProcess, QProcessEnvironment, pyqt
 from PyQt5.QtWidgets import QMessageBox, QPushButton
 
 from legendary.models.game import LaunchParameters
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton
 from rare.components.dialogs.uninstall_dialog import UninstallDialog
 from rare.components.extra.console import ConsoleWindow
 from rare.components.tabs.games import CloudSaveUtils
@@ -50,8 +50,10 @@ class GameUtils(QObject):
 
     def __init__(self, parent=None):
         super(GameUtils, self).__init__(parent=parent)
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
 
-        self.core = shared.core
         self.console = ConsoleWindow()
         self.cloud_save_utils = CloudSaveUtils()
         self.cloud_save_utils.sync_finished.connect(self.sync_finished)
@@ -80,7 +82,7 @@ class GameUtils(QObject):
         if infos == 0:
             return False
         legendary_utils.uninstall(game.app_name, self.core, infos)
-        shared.signals.game_uninstalled.emit(app_name)
+        self.signals.game_uninstalled.emit(app_name)
         return True
 
     def prepare_launch(
@@ -116,7 +118,7 @@ class GameUtils(QObject):
             wine_pfx: str = None,
             ask_always_sync: bool = False,
     ):
-        if shared.args.offline:
+        if self.args.offline:
             offline = True
         game = self.core.get_game(app_name)
         igame = self.core.get_installed_game(app_name)
@@ -253,7 +255,7 @@ class GameUtils(QObject):
             self.running_games[game.app_name] = running_game
 
         else:
-            origin_uri = self.core.get_origin_uri(game.app_name, shared.args.offline)
+            origin_uri = self.core.get_origin_uri(game.app_name, self.args.offline)
             logger.info("Launch Origin Game: ")
             if platform.system() == "Windows":
                 webbrowser.open(origin_uri)

--- a/rare/components/tabs/games/game_widgets/base_installed_widget.py
+++ b/rare/components/tabs/games/game_widgets/base_installed_widget.py
@@ -6,7 +6,7 @@ from PyQt5.QtCore import pyqtSignal, QProcess, QSettings, Qt, QByteArray
 from PyQt5.QtGui import QPixmap
 from PyQt5.QtWidgets import QGroupBox, QMessageBox, QAction, QLabel
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton, ArgumentsSingleton
 from rare.components.tabs.games.game_utils import GameUtils
 from rare.utils import utils
 from rare.utils.utils import create_desktop_link
@@ -22,7 +22,9 @@ class BaseInstalledWidget(QGroupBox):
 
     def __init__(self, app_name, pixmap: QPixmap, game_utils: GameUtils):
         super(BaseInstalledWidget, self).__init__()
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
+        self.args = ArgumentsSingleton()
         self.game_utils = game_utils
 
         self.syncing_cloud_saves = False
@@ -53,7 +55,7 @@ class BaseInstalledWidget(QGroupBox):
             pixmap.scaled(200, int(200 * 4 / 3), transformMode=Qt.SmoothTransformation)
         )
         self.game_running = False
-        self.offline = shared.args.offline
+        self.offline = self.args.offline
         self.update_available = False
         if self.igame and self.core.lgd.assets:
             try:
@@ -120,7 +122,7 @@ class BaseInstalledWidget(QGroupBox):
 
         uninstall = QAction(self.tr("Uninstall"), self)
         uninstall.triggered.connect(
-            lambda: shared.signals.update_gamelist.emit([self.game.app_name])
+            lambda: self.signals.update_gamelist.emit([self.game.app_name])
             if self.game_utils.uninstall_game(self.game.app_name)
             else None
         )

--- a/rare/components/tabs/games/game_widgets/installed_icon_widget.py
+++ b/rare/components/tabs/games/game_widgets/installed_icon_widget.py
@@ -4,7 +4,7 @@ from PyQt5.QtCore import QEvent, pyqtSignal, QSize, Qt
 from PyQt5.QtGui import QMouseEvent
 from PyQt5.QtWidgets import QVBoxLayout, QHBoxLayout, QPushButton, QLabel
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton
 from rare.components.tabs.games.game_widgets.base_installed_widget import (
     BaseInstalledWidget,
 )
@@ -22,7 +22,7 @@ class InstalledIconWidget(BaseInstalledWidget):
 
         self.setContextMenuPolicy(Qt.ActionsContextMenu)
         self.layout = QVBoxLayout()
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
 
         if self.update_available:
             logger.info(f"Update available for game: {self.game.app_name}")

--- a/rare/components/tabs/games/game_widgets/installing_game_widget.py
+++ b/rare/components/tabs/games/game_widgets/installing_game_widget.py
@@ -3,7 +3,7 @@ from PyQt5.QtGui import QPaintEvent, QPainter, QPixmap, QPen, QFont, QColor
 from PyQt5.QtWidgets import QVBoxLayout, QLabel, QHBoxLayout, QWidget
 
 from legendary.models.game import Game
-from rare import shared
+from rare.shared import LegendaryCoreSingleton
 from rare.utils.utils import (
     get_pixmap,
     optimal_text_background,
@@ -20,6 +20,8 @@ class InstallingGameWidget(QWidget):
         self.setObjectName("game_widget_icon")
         self.setProperty("noBorder", 1)
         self.setLayout(QVBoxLayout())
+
+        self.core = LegendaryCoreSingleton()
 
         self.pixmap = QPixmap()
         w = 200
@@ -42,7 +44,7 @@ class InstallingGameWidget(QWidget):
         if not app_name:
             self.game = None
             return
-        self.game = shared.core.get_game(app_name)
+        self.game = self.core.get_game(app_name)
         self.title_label.setText(f"<h4>{self.game.app_title}</h4>")
 
         self.image_widget.set_game(self.game.app_name)
@@ -59,9 +61,10 @@ class PaintWidget(QWidget):
 
     def __init__(self):
         super(PaintWidget, self).__init__()
+        self.core = LegendaryCoreSingleton()
 
     def set_game(self, app_name: str):
-        game = shared.core.get_game(app_name, False)
+        game = self.core.get_game(app_name, False)
         self.color_image = get_pixmap(game.app_name)
         w = 200
         self.color_image = self.color_image.scaled(

--- a/rare/components/tabs/games/head_bar.py
+++ b/rare/components/tabs/games/head_bar.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
     QComboBox,
 )
 
-from rare import shared
+from rare.shared import ApiResultsSingleton
 from rare.utils.extra_widgets import SelectViewWidget
 from rare.utils.utils import icon
 
@@ -18,6 +18,7 @@ class GameListHeadBar(QWidget):
 
     def __init__(self, parent=None):
         super(GameListHeadBar, self).__init__(parent=parent)
+        self.api_results = ApiResultsSingleton()
         self.setLayout(QHBoxLayout())
         # self.installed_only = QCheckBox(self.tr("Installed only"))
         self.settings = QSettings()
@@ -38,15 +39,15 @@ class GameListHeadBar(QWidget):
             "installed",
             "offline",
         ]
-        if shared.api_results.bit32_games:
+        if self.api_results.bit32_games:
             self.filter.addItem(self.tr("32 Bit Games"))
             self.available_filters.append("32bit")
 
-        if shared.api_results.mac_games:
+        if self.api_results.mac_games:
             self.filter.addItem(self.tr("Mac games"))
             self.available_filters.append("mac")
 
-        if shared.api_results.no_asset_games:
+        if self.api_results.no_asset_games:
             self.filter.addItem(self.tr("Exclude Origin"))
             self.available_filters.append("installable")
 

--- a/rare/components/tabs/settings/dxvk.py
+++ b/rare/components/tabs/settings/dxvk.py
@@ -2,7 +2,7 @@ from logging import getLogger
 
 from PyQt5.QtWidgets import QGroupBox
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton
 from rare.ui.components.tabs.settings.dxvk import Ui_DxvkSettings
 
 logger = getLogger("DXVK Settings")
@@ -14,7 +14,7 @@ class DxvkSettings(QGroupBox, Ui_DxvkSettings):
         self.setupUi(self)
 
         self.name = name if name is not None else "default"
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
 
         self.dxvk_options_map = {
             "devinfo": self.devinfo,

--- a/rare/components/tabs/settings/legendary.py
+++ b/rare/components/tabs/settings/legendary.py
@@ -5,7 +5,7 @@ from typing import Tuple
 from PyQt5.QtCore import Qt, QRunnable, QObject, pyqtSignal, QThreadPool
 from PyQt5.QtWidgets import QSizePolicy, QWidget, QFileDialog, QMessageBox
 
-import rare.shared as shared
+from rare.shared import LegendaryCoreSingleton
 from rare.components.tabs.settings.eos import EosWidget
 from rare.components.tabs.settings.ubisoft_activation import UbiActivationHelper
 from rare.ui.components.tabs.settings.legendary import Ui_LegendarySettings
@@ -15,21 +15,22 @@ from rare.utils.utils import get_size
 logger = getLogger("LegendarySettings")
 
 
-class WorkerSignals(QObject):
+class RefreshGameMetaSignals(QObject):
     finished = pyqtSignal()
 
     def __init__(self):
-        super(WorkerSignals, self).__init__()
+        super(RefreshGameMetaSignals, self).__init__()
 
 
 class RefreshGameMetaWorker(QRunnable):
     def __init__(self):
         super(RefreshGameMetaWorker, self).__init__()
+        self.signals = RefreshGameMetaSignals()
         self.setAutoDelete(True)
-        self.signals = WorkerSignals()
+        self.core = LegendaryCoreSingleton()
 
     def run(self) -> None:
-        shared.core.get_game_and_dlc_list(True, force_refresh=True)
+        self.core.get_game_and_dlc_list(True, force_refresh=True)
         self.signals.finished.emit()
 
 
@@ -38,7 +39,7 @@ class LegendarySettings(QWidget, Ui_LegendarySettings):
         super(LegendarySettings, self).__init__(parent=parent)
         self.setupUi(self)
 
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
 
         # Default installation directory
         self.install_dir = PathEdit(

--- a/rare/components/tabs/settings/rare.py
+++ b/rare/components/tabs/settings/rare.py
@@ -7,8 +7,7 @@ from logging import getLogger
 from PyQt5.QtCore import QSettings, Qt
 from PyQt5.QtWidgets import QWidget, QMessageBox
 
-from rare import shared
-
+from rare.shared import LegendaryCoreSingleton
 from rare.components.tabs.settings.rpc import RPCSettings
 from rare.ui.components.tabs.settings.rare import Ui_RareSettings
 from rare.utils import utils
@@ -35,7 +34,7 @@ class RareSettings(QWidget, Ui_RareSettings):
     def __init__(self):
         super(RareSettings, self).__init__()
         self.setupUi(self)
-        self.core = shared.core
+        self.core = LegendaryCoreSingleton()
         # (widget_name, option_name, default)
         self.checkboxes = [
             (self.sys_tray, "sys_tray", True),

--- a/rare/components/tabs/shop/__init__.py
+++ b/rare/components/tabs/shop/__init__.py
@@ -1,7 +1,7 @@
 from PyQt5.QtWidgets import QStackedWidget, QTabWidget
 
 from legendary.core import LegendaryCore
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, ApiResultsSingleton
 from rare.utils.paths import cache_dir
 from .game_info import ShopGameInfo
 from .search_results import SearchResults
@@ -16,13 +16,14 @@ class Shop(QStackedWidget):
     def __init__(self, core: LegendaryCore):
         super(Shop, self).__init__()
         self.core = core
+        self.api_results = ApiResultsSingleton()
         self.api_core = ShopApiCore(
             self.core.egs.session.headers["Authorization"],
             self.core.language_code,
             self.core.country_code,
         )
 
-        self.shop = ShopWidget(cache_dir, core, self.api_core)
+        self.shop = ShopWidget(cache_dir, self.core, self.api_core)
         self.wishlist_widget = Wishlist(self.api_core)
 
         self.store_tabs = QTabWidget()
@@ -35,7 +36,7 @@ class Shop(QStackedWidget):
         self.addWidget(self.search_results)
         self.search_results.show_info.connect(self.show_game_info)
         self.info = ShopGameInfo(
-            [i.asset_infos["Windows"].namespace for i in shared.api_results.game_list],
+            [i.asset_infos["Windows"].namespace for i in self.api_results.game_list],
             self.api_core,
         )
         self.addWidget(self.info)

--- a/rare/components/tabs/shop/game_info.py
+++ b/rare/components/tabs/shop/game_info.py
@@ -13,7 +13,7 @@ from PyQt5.QtWidgets import (
     QGridLayout,
 )
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton
 from rare.components.tabs.shop.shop_models import ShopGame
 from rare.ui.components.tabs.store.shop_game_info import Ui_shop_info
 from rare.utils.extra_widgets import WaitingSpinner, ImageLabel
@@ -30,6 +30,7 @@ class ShopGameInfo(QWidget, Ui_shop_info):
     def __init__(self, installed_titles: list, api_core):
         super(ShopGameInfo, self).__init__()
         self.setupUi(self)
+        self.core = LegendaryCoreSingleton()
         self.api_core = api_core
         self.installed = installed_titles
         self.open_store_button.clicked.connect(self.button_clicked)
@@ -258,7 +259,7 @@ class ShopGameInfo(QWidget, Ui_shop_info):
             self.wishlist.append(game["offer"]["title"])
 
     def button_clicked(self):
-        QDesktopServices.openUrl(QUrl(f"https://www.epicgames.com/store/{shared.core.language_code}/p/{self.slug}"))
+        QDesktopServices.openUrl(QUrl(f"https://www.epicgames.com/store/{self.core.language_code}/p/{self.slug}"))
 
 
 class SocialButton(QPushButton):

--- a/rare/components/tray_icon.py
+++ b/rare/components/tray_icon.py
@@ -3,13 +3,15 @@ from typing import List
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QSystemTrayIcon, QMenu, QAction
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton
 from rare.utils.meta import GameMeta
 
 
 class TrayIcon(QSystemTrayIcon):
     def __init__(self, parent):
         super(TrayIcon, self).__init__(parent)
+        self.core = LegendaryCoreSingleton()
+
         self.setIcon(QIcon(":/images/Rare.png"))
         self.setVisible(True)
         self.setToolTip("Rare")
@@ -24,7 +26,7 @@ class TrayIcon(QSystemTrayIcon):
         self.text_action.setEnabled(False)
         self.menu.addAction(self.text_action)
 
-        if len(installed := shared.core.get_installed_list()) < 5:
+        if len(installed := self.core.get_installed_list()) < 5:
             last_played = [GameMeta(i.app_name) for i in sorted(installed, key=lambda x: x.title)]
         elif games := sorted(
                 parent.mainwindow.tab_widget.games_tab.game_utils.game_meta.get_games(),
@@ -36,7 +38,7 @@ class TrayIcon(QSystemTrayIcon):
         self.game_actions = []
 
         for game in last_played:
-            a = QAction(shared.core.get_game(game.app_name).app_title)
+            a = QAction(self.core.get_game(game.app_name).app_title)
             a.setProperty("app_name", game.app_name)
             self.game_actions.append(a)
             a.triggered.connect(

--- a/rare/shared.py
+++ b/rare/shared.py
@@ -1,31 +1,38 @@
 from argparse import Namespace
 
 from legendary.core import LegendaryCore
-from rare.utils.models import ApiResults, Signals
+from rare.utils.models import ApiResults, GlobalSignals
 
-core: LegendaryCore = None
-signals: Signals = None
-args: Namespace = None
-api_results: ApiResults = None
-
-
-def init_legendary():
-    global core
-    core = LegendaryCore()
-    return core
+_legendary_core_singleton: LegendaryCore = None
+_global_signals_singleton: GlobalSignals = None
+_arguments_singleton: Namespace = None
+_api_results_singleton: ApiResults = None
 
 
-def init_signals():
-    global signals
-    signals = Signals()
-    return signals
+def LegendaryCoreSingleton() -> LegendaryCore:
+    global _legendary_core_singleton
+    if _legendary_core_singleton is None:
+        _legendary_core_singleton = LegendaryCore()
+    return _legendary_core_singleton
 
 
-def init_args(a: Namespace):
-    global args
-    args = a
+def GlobalSignalsSingleton() -> GlobalSignals:
+    global _global_signals_singleton
+    if _global_signals_singleton is None:
+        _global_signals_singleton = GlobalSignals()
+    return _global_signals_singleton
 
 
-def init_api_response(res: ApiResults):
-    global api_results
-    api_results = res
+def ArgumentsSingleton(args: Namespace = None) -> Namespace:
+    global _arguments_singleton
+    if _arguments_singleton is None:
+        _arguments_singleton = args
+    return _arguments_singleton
+
+
+def ApiResultsSingleton(res: ApiResults = None) -> ApiResults:
+    global _api_results_singleton
+    if _api_results_singleton is None:
+        _api_results_singleton = res
+    return _api_results_singleton
+

--- a/rare/utils/models.py
+++ b/rare/utils/models.py
@@ -121,7 +121,7 @@ class ApiResults:
         )
 
 
-class Signals(QObject):
+class GlobalSignals(QObject):
     exit_app = pyqtSignal(int)  # exit code
     send_notification = pyqtSignal(str)  # app_title
 

--- a/rare/utils/rpc.py
+++ b/rare/utils/rpc.py
@@ -6,7 +6,7 @@ import pypresence.exceptions
 from PyQt5.QtCore import QObject, QSettings
 from pypresence import Presence
 
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, GlobalSignalsSingleton
 
 client_id = "830732538225360908"
 logger = getLogger("RPC")
@@ -17,8 +17,8 @@ class DiscordRPC(QObject):
         super(DiscordRPC, self).__init__()
         self.RPC = None
         self.state = 1  # 0: game, 1: always active, 2: off
-        self.core = shared.core
-        self.signals = shared.signals
+        self.core = LegendaryCoreSingleton()
+        self.signals = GlobalSignalsSingleton()
 
         self.settings = QSettings()
         if self.settings.value("rpc_enable", 0, int) == 1:  # show always

--- a/rare/utils/steam_grades.py
+++ b/rare/utils/steam_grades.py
@@ -7,7 +7,7 @@ import requests
 from PyQt5.QtCore import pyqtSignal, QRunnable, QObject, QCoreApplication
 
 from legendary.core import LegendaryCore
-from rare import shared
+from rare.shared import LegendaryCoreSingleton, ArgumentsSingleton
 from rare.utils.paths import data_dir, cache_dir
 
 replace_chars = ",;.:-_ "
@@ -48,15 +48,17 @@ class SteamWorker(QRunnable):
 
 
 def get_rating(app_name: str):
+    core = LegendaryCoreSingleton()
+    args = ArgumentsSingleton()
     if os.path.exists(p := os.path.join(data_dir, "steam_ids.json")):
         grades = json.load(open(p))
     else:
         grades = {}
 
     if not grades.get(app_name):
-        if shared.args.offline:
+        if args.offline:
             return "pending"
-        game = shared.core.get_game(app_name)
+        game = core.get_game(app_name)
 
         steam_id = get_steam_id(game.app_title)
         grade = get_grade(steam_id)


### PR DESCRIPTION
As the title suggests, remove the global objects in shared and instead used functions to instantiate or return them.

They are still reside in `rare.shared` but that doesn't need to be the case any more. They can be moved into the same files
where each class is implemented for better concept encapsulation. I left them there to make the change-set as minimal as possible
because we have various branches running around right now.

I also sneaked in a few worker signal classes renames, as it was getting confusing to keep track what signals each field was referring too.