### PR TITLE
Fix crash upon opening game info while verifying

### DIFF
--- a/rare/components/tabs/games/game_info/game_info.py
+++ b/rare/components/tabs/games/game_info/game_info.py
@@ -199,7 +199,7 @@ class GameInfo(QWidget, Ui_GameInfo):
         elif self.verify_threads.get(self.game.app_name):
             self.verify_widget.setCurrentIndex(1)
             self.verify_progress.setValue(
-                self.verify_threads[self.game.app_name].num
-                / self.verify_threads[self.game.app_name].total
-                * 100
+                int(self.verify_threads[self.game.app_name].num
+                    / self.verify_threads[self.game.app_name].total
+                    * 100)
             )


### PR DESCRIPTION
Initially reported on Discord, Rare currently crashes when opening game info while that game is being verified. This PR is a simple `float` to `int` conversion in the progress value of the verification progress bar to address exactly that.