### PR TITLE
 Adds the Chocolatey package as a way to install Rare

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,13 @@ manually in `Settings -> Security and Privacy`. Otherwise, Gatekeeper will block
 
 You can also use `pip`.
 
+### windows
+
+Rare is available as a [Chocolatey package](https://community.chocolatey.org/packages/rare) on Windows.
+You can install rare with the following one-liner:
+
+`choco install rare`
+
 ### Packages
 
 In [releases page](https://github.com/Dummerle/Rare/releases), AppImages are available for Linux, a .msi file for windows and a .dmg


### PR DESCRIPTION
Hi @rare_devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1099) and now, we can install **rare** using [Chocolatey](https://community.chocolatey.org/packages/rare).

For now, only the latest version (`1.8.9`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

