### PR TITLE
Lgndr: Update to legendary 0.20.29

### DIFF
--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -6,7 +6,30 @@ on:
   workflow_dispatch:
 
 jobs:
+  version:
+    name: "Describe version"
+    runs-on: ubuntu-latest
+    outputs:
+      tag_abbrev: ${{ steps.version.outputs.tag_abbrev }}
+      tag_offset: ${{ steps.version.outputs.tag_offset }}
+      sha_short: ${{ steps.version.outputs.sha_short }}
+      full_desc: ${{ steps.version.outputs.full_desc }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Version
+        id: version
+        shell: bash
+        run: |
+          tag_abbrev=$(git describe --tags --abbrev=0)
+          echo "::set-output name=tag_abbrev::${tag_abbrev%%-rc*}"
+          echo "::set-output name=tag_offset::$(git rev-list $tag_abbrev..HEAD --count)"
+          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+          echo "::set-output name=full_desc::$(git describe --long --tags)"
+
   deb-package:
+    needs: version
     runs-on: ubuntu-latest
     steps:
       - name: Install Makedeb
@@ -34,11 +57,10 @@ jobs:
           path: build/Rare.deb
 
   appimage:
+    needs: version
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
+      - uses: actions/checkout@v3
       - name: install Deps
         run: |
           sudo apt update
@@ -61,11 +83,10 @@ jobs:
           path: Rare.AppImage
 
   nuitka:
+    needs: version
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
@@ -76,15 +97,6 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           pip3 install -r requirements-presence.txt
-      - name: Versions
-        id: version
-        shell: bash
-        run: |
-          tag_abbrev=$(git describe --tags --abbrev=0)
-          echo "::set-output name=tag_abbrev::${tag_abbrev%%-rc*}"
-          echo "::set-output name=tag_offset::$(git rev-list $tag_abbrev..HEAD --count)"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=full_desc::$(git describe --long --tags)"
       - name: Build
         run: >-
           python -m nuitka
@@ -111,23 +123,22 @@ jobs:
           --windows-company-name=Rare
           --windows-product-name=Rare
           --windows-file-description=rare.exe
-          --windows-file-version=${{ steps.version.outputs.tag_abbrev }}.${{ steps.version.outputs.tag_offset }}
-          --windows-product-version=${{ steps.version.outputs.tag_abbrev }}.${{ steps.version.outputs.tag_offset }}
+          --windows-file-version=${{ needs.version.outputs.tag_abbrev }}.${{ needs.version.outputs.tag_offset }}
+          --windows-product-version=${{ needs.version.outputs.tag_abbrev }}.${{ needs.version.outputs.tag_offset }}
           --enable-console
           rare
 
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: Rare-Windows-${{ steps.version.outputs.tag_abbrev }}.${{ steps.version.outputs.tag_offset }}
+          name: Rare-Windows-${{ needs.version.outputs.tag_abbrev }}.${{ needs.version.outputs.tag_offset }}
           path: rare.dist
 
   cx_freeze:
+    needs: version
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
@@ -138,15 +149,6 @@ jobs:
         run: |
           pip3 install -r requirements.txt
           pip3 install -r requirements-presence.txt
-      - name: Versions
-        id: version
-        shell: bash
-        run: |
-          tag_abbrev=$(git describe --tags --abbrev=0)
-          echo "::set-output name=tag_abbrev::${tag_abbrev%%-rc*}"
-          echo "::set-output name=tag_offset::$(git rev-list $tag_abbrev..HEAD --count)"
-          echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
-          echo "::set-output name=full_desc::$(git describe --long --tags)"
       - name: Build
         run: |
           python freeze.py bdist_msi
@@ -155,10 +157,11 @@ jobs:
       - name: Upload to Artifacts
         uses: actions/upload-artifact@v3
         with:
-          name: Rare-Windows-${{ steps.version.outputs.tag_abbrev }}.${{ steps.version.outputs.tag_offset }}.msi
+          name: Rare-Windows-${{ needs.version.outputs.tag_abbrev }}.${{ needs.version.outputs.tag_offset }}.msi
           path: dist/*.msi
 
   mac_os:
+    needs: version
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/release-tests.yml
+++ b/.github/workflows/release-tests.yml
@@ -1,5 +1,5 @@
 
-name: "Release Tests"
+name: "Development Snapshot"
 
 
 on:
@@ -22,8 +22,8 @@ jobs:
         id: version
         shell: bash
         run: |
-          tag_abbrev=$(git describe --tags --abbrev=0)
-          echo "::set-output name=tag_abbrev::${tag_abbrev%%-rc*}"
+          tag_abbrev=$(git tag | sort -h | grep -oE "(^[0-9]+\.[0-9]+(.[0-9])?)$" | tail -1)
+          echo "::set-output name=tag_abbrev::$tag_abbrev"
           echo "::set-output name=tag_offset::$(git rev-list $tag_abbrev..HEAD --count)"
           echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
           echo "::set-output name=full_desc::$(git describe --long --tags)"
@@ -38,7 +38,7 @@ jobs:
           echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
           sudo apt update
           sudo apt install makedeb
-      - name: prepare source directory
+      - name: Prepare source directory
         run: |
           git clone https://mpr.hunterwittenborn.com/rare.git build
           sed -i 's/source=.*/source=("rare-test::git+$url")/g' build/PKGBUILD
@@ -61,23 +61,23 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
-      - name: install Deps
+      - name: Install build dependencies
         run: |
           sudo apt update
           sudo apt install python3 python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
-      - name: install appimage-builder
+      - name: Install appimage-builder
         run: |
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
           sudo pip3 install appimage-builder
-      - name: Build Appimage
+      - name: Build
         run: |
           cp rare/__main__.py .
           appimage-builder --skip-test
           mv Rare-*.AppImage Rare.AppImage
 
       - name: Upload to Artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: Rare.AppImage
           path: Rare.AppImage
@@ -165,22 +165,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-
-      - name: Pip Dependencies
+      - name: Install Build Dependencies
+        run: pip install pyinstaller
+      - name: Install Target Dependencies
         run: |
           pip install -r requirements.txt
-          pip install pyinstaller
-
-      - name: copy files
+      - name: Move files
         run: mv rare/__main__.py __main__.py
-
-      - name: run pyinstaller
+      - name: Build
         run: >-
           pyinstaller -F --name Rare
           --add-data "rare/resources/languages/*:rare/resources/languages"
@@ -189,8 +184,7 @@ jobs:
           --icon rare/resources/images/Rare.icns
           --hidden-import=legendary
           __main__.py
-
-      - name: create dmg
+      - name: Create dmg
         run: |
           git clone https://github.com/create-dmg/create-dmg
           create-dmg/create-dmg Rare-${{github.ref}}.dmg dist/Rare.App --volname Rare --volicon rare/resources/images/Rare.icns

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           echo 'deb [signed-by=/usr/share/keyrings/makedeb-archive-keyring.gpg arch=all] https://proget.hunterwittenborn.com/ makedeb main' | sudo tee /etc/apt/sources.list.d/makedeb.list
           sudo apt update
           sudo apt install makedeb
-      - name: prepare pkgbuild
+      - name: Prepare source directory
         run: |
           git clone https://mpr.hunterwittenborn.com/rare.git build
           sed -i "s/pkgver=.*/pkgver=${{ github.event.release.tag_name }}/g" build/PKGBUILD
@@ -63,19 +63,17 @@ jobs:
   appimage:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - name: install Deps
+      - uses: actions/checkout@v3
+      - name: Install build dependencies
         run: |
           sudo apt update
           sudo apt install python3 python3-pip python3-setuptools patchelf desktop-file-utils libgdk-pixbuf2.0-dev fakeroot strace fuse
-      - name: install appimage-builder
+      - name: Install appimage-builder
         run: |
           sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /usr/local/bin/appimagetool
           sudo chmod +x /usr/local/bin/appimagetool
           sudo pip3 install appimage-builder
-      - name: Build Appimage
+      - name: Build
         run: |
           cp rare/__main__.py .
           appimage-builder --skip-test
@@ -103,8 +101,6 @@ jobs:
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
@@ -162,8 +158,6 @@ jobs:
     runs-on: "windows-latest"
     steps:
       - uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
@@ -192,22 +186,17 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
-        with:
-          submodules: true
-
       - uses: actions/setup-python@v4
         with:
           python-version: '3.9'
-
-      - name: Pip Dependencies
+      - name: Install Build Dependencies
+        run: pip install pyinstaller
+      - name: Install Target Dependencies
         run: |
           pip install -r requirements.txt
-          pip install pyinstaller
-
-      - name: copy files
+      - name: Move files
         run: mv rare/__main__.py __main__.py
-
-      - name: run pyinstaller
+      - name: Build
         run: >-
           pyinstaller -F --name Rare
           --add-data "rare/resources/languages/*:rare/resources/languages"
@@ -216,8 +205,7 @@ jobs:
           --icon rare/resources/images/Rare.icns
           --hidden-import=legendary
           __main__.py
-
-      - name: create dmg
+      - name: Create dmg
         run: |
           git clone https://github.com/create-dmg/create-dmg
           create-dmg/create-dmg Rare.dmg dist/Rare.App --volname Rare --volicon rare/resources/images/Rare.icns

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ pywebview = [
     { version = "^3.6.3", extras = ["cef"], platform = "windows", optional = true },
     { version = "^3.6.3", extras = ["gtk"], platform = "linux", optional = true },
 ]
-legendary-gl = "^0.20.28"
+legendary-gl = "^0.20.29"
 typing-extensions = "^4.3.0"
 
 [tool.poetry.scripts]

--- a/rare/components/dialogs/install_dialog.py
+++ b/rare/components/dialogs/install_dialog.py
@@ -292,8 +292,11 @@ class InstallDialog(QDialog):
                 self.ui.install_prereqs_check.setVisible(True)
                 self.ui.install_prereqs_lbl.setVisible(True)
                 self.ui.install_prereqs_check.setChecked(True)
+                prereq_name = dl_item.igame.prereq_info.get("name", "")
+                prereq_path = os.path.split(dl_item.igame.prereq_info.get("path", ""))[-1]
+                prereq_desc = prereq_name if prereq_name else prereq_path
                 self.ui.install_prereqs_check.setText(
-                    self.tr("Also install: {}").format(dl_item.igame.prereq_info.get("name", ""))
+                    self.tr("Also install: {}").format(prereq_desc)
                 )
         if self.silent:
             self.close()

--- a/rare/components/tabs/downloads/download_thread.py
+++ b/rare/components/tabs/downloads/download_thread.py
@@ -154,9 +154,10 @@ class DownloadThread(QThread):
                 proc.readyReadStandardOutput.connect(
                     lambda: logger.debug(str(proc.readAllStandardOutput().data(), "utf-8", "ignore"))
                 )
-                proc.setArguments(postinstall.get("args", []))
+                proc.setProgram(fullpath)
+                proc.setArguments(postinstall.get("args", "").split(" "))
                 proc.setWorkingDirectory(work_dir)
-                proc.start(fullpath)
+                proc.start()
                 proc.waitForFinished()  # wait, because it is inside the thread
         else:
             logger.info("Automatic installation not available on Linux.")

--- a/rare/components/tabs/downloads/download_thread.py
+++ b/rare/components/tabs/downloads/download_thread.py
@@ -140,10 +140,7 @@ class DownloadThread(QThread):
         logger.info("This game lists the following prerequisites to be installed:")
         logger.info(f'- {postinstall["name"]}: {" ".join((postinstall["path"], postinstall["args"]))}')
         if platform.system() == "Windows":
-            if not self.item.options.install_prereqs:
-                logger.info("Marking prerequisites as installed...")
-                self.core.prereq_installed(self.item.download.igame.app_name)
-            else:
+            if self.item.options.install_prereqs:
                 logger.info("Launching prerequisite executable..")
                 self.core.prereq_installed(igame.app_name)
                 req_path, req_exec = os.path.split(postinstall["path"])

--- a/rare/components/tabs/downloads/download_thread.py
+++ b/rare/components/tabs/downloads/download_thread.py
@@ -137,7 +137,7 @@ class DownloadThread(QThread):
         self.ret_status.emit(ret)
 
     def _handle_postinstall(self, postinstall, igame):
-        logger.info("This game lists the following prequisites to be installed:")
+        logger.info("This game lists the following prerequisites to be installed:")
         logger.info(f'- {postinstall["name"]}: {" ".join((postinstall["path"], postinstall["args"]))}')
         if platform.system() == "Windows":
             if not self.item.options.install_prereqs:
@@ -154,7 +154,7 @@ class DownloadThread(QThread):
                 proc.readyReadStandardOutput.connect(
                     lambda: logger.debug(str(proc.readAllStandardOutput().data(), "utf-8", "ignore"))
                 )
-                proc.setNativeArguments(postinstall.get("args", []))
+                proc.setArguments(postinstall.get("args", []))
                 proc.setWorkingDirectory(work_dir)
                 proc.start(fullpath)
                 proc.waitForFinished()  # wait, because it is inside the thread

--- a/rare/game_launch_helper/__init__.py
+++ b/rare/game_launch_helper/__init__.py
@@ -208,7 +208,9 @@ class GameProcessApp(RareApp):
             self.server.deleteLater()
         except RuntimeError:
             pass
-        self.exit_app.emit()
+        self.processEvents()
+        if not self.console:
+            self.exit()
 
 
 def start_game(args: Namespace):

--- a/rare/lgndr/cli.py
+++ b/rare/lgndr/cli.py
@@ -307,7 +307,7 @@ class LegendaryCLI(LegendaryCLIReal):
         # noinspection PyShadowingBuiltins
         def print(x): self.logger.info(x) if x else None
         # noinspection PyShadowingBuiltins
-        def input(x): return 'y' if choice else 'i'
+        def input(x): return 'y' if choice else 'n'
 
         print('\nThis game lists the following prerequisites to be installed:')
         print(f'- {postinstall["name"]}: {" ".join((postinstall["path"], postinstall["args"]))}')

--- a/rare/lgndr/cli.py
+++ b/rare/lgndr/cli.py
@@ -442,7 +442,7 @@ class LegendaryCLI(LegendaryCLIReal):
             percentage = (processed / total_size) * 100.0
             num += 1
 
-            if (delta := ((current_time := time.time()) - last_update)) > 1 or (not last_processed and delta > 1):
+            if (delta := ((current_time := time.time()) - last_update)) > 1:
                 last_update = current_time
                 speed = (processed - last_processed) / 1024 / 1024 / delta
                 last_processed = processed

--- a/rare/lgndr/core.py
+++ b/rare/lgndr/core.py
@@ -28,30 +28,6 @@ class LegendaryCore(LegendaryCoreReal):
     # def get_installed_game(self, app_name, skip_sync=True) -> InstalledGame:
     #     return super(LegendaryCore, self).get_installed_game(app_name, skip_sync)
 
-    # FIXME: delete this when legendary merges https://github.com/derrod/legendary/pull/477
-    def get_cdn_manifest(self, game, platform='Windows', disable_https=False):
-        manifest_urls, base_urls, manifest_hash = self.get_cdn_urls(game, platform)
-
-        if disable_https:
-            manifest_urls = [url.replace('https://', 'http://') for url in manifest_urls]
-
-        manifest_bytes = None
-        for url in manifest_urls:
-            self.log.debug(f'Trying to download manifest from {url} ...')
-            r = self.egs.unauth_session.get(url)
-            if r.ok:
-                manifest_bytes = r.content
-                break
-            else:
-                self.log.warning(f'Unable to download manifest from {url}, trying next one ...')
-        if not manifest_bytes:
-            raise ValueError('Unable to get manifest data from any CDN URL')
-
-        if sha1(manifest_bytes).hexdigest() != manifest_hash:
-            raise ValueError('Manifest sha hash mismatch!')
-
-        return manifest_bytes, base_urls
-
     def prepare_download(self, game: Game, base_game: Game = None, base_path: str = '',
                          status_q: Queue = None, max_shm: int = 0, max_workers: int = 0,
                          force: bool = False, disable_patching: bool = False,


### PR DESCRIPTION
The division by zero error in `validate_files` was fixed in Legendary `0.20.29`, which also contains the reworked `get_cdn_manifest`, so that was removed too.