### PR TITLE
rare.desktop: fix categories

### DIFF
--- a/misc/rare.desktop
+++ b/misc/rare.desktop
@@ -1,7 +1,7 @@
 [Desktop Entry]
 Name=Rare
 Type=Application
-Categories=Games;Multimedia;
+Categories=Game;
 Icon=rare
 Exec=rare
 Comment=A GUI for legendary, an open source replacement for Epic Games Launcher


### PR DESCRIPTION
The `Games` and `Multimedia` categories don't exist https://specifications.freedesktop.org/menu-spec/latest/apa.html