### PR TITLE
RareCore: Handle exception when fetching non-asset games

### DIFF
--- a/rare/shared/rare_core.py
+++ b/rare/shared/rare_core.py
@@ -51,6 +51,7 @@ class RareCore(QObject):
         self.__core: Optional[LegendaryCore] = None
         self.__image_manager: Optional[ImageManager] = None
 
+        self.__start_time = time.time()
         self.__fetched_games: List = []
         self.__fetched_dlcs: Dict = {}
 
@@ -281,7 +282,11 @@ class RareCore(QObject):
         if res_type == FetchWorker.Result.NON_ASSET:
             games, dlc_dict = result
             self.__fetched_games += games
-            self.__fetched_dlcs.update(dlc_dict)
+            for catalog_id, dlcs in dlc_dict.items():
+                if catalog_id in self.__fetched_dlcs.keys():
+                    self.__fetched_dlcs[catalog_id] += dlcs
+                else:
+                    self.__fetched_dlcs[catalog_id] = dlcs
             self.__non_asset_fetched = True
             status = self.tr("Prepared games without assets")
         logger.info(f"Got API results for {FetchWorker.Result(res_type).name}")

--- a/rare/shared/workers/fetch.py
+++ b/rare/shared/workers/fetch.py
@@ -44,6 +44,15 @@ class NonAssetWorker(FetchWorker):
         except (HTTPError, ConnectionError) as e:
             logger.warning(f"Exception while fetching non asset games from EGS: {e}")
             result = ([], {})
+        # FIXME:
+        #  This is here because of broken appIds from Epic:
+        #  https://discord.com/channels/826881530310819914/884510635642216499/1111321692703305729
+        #  There is a tab character in the appId of Fallout New Vegas: Honest Hearts DLC, this breaks metadata storage
+        #  on Windows as they can't handle tabs at the end of the filename (?)
+        #  Legendary and Heroic are also affected, but it completed breaks Rare, so dodge it for now pending a fix.
+        except Exception as e:
+            logger.error(f"Exception while fetching non asset games from EGS: {e}")
+            result = ([], {})
         self.signals.result.emit(result, FetchWorker.Result.NON_ASSET)
         logger.debug(f"Non asset: {len(result[0])}, DLCs {len(result[1])}")
         logger.debug(f"Request Non Asset: {time.time() - start_time} seconds")


### PR DESCRIPTION
https://discord.com/channels/826881530310819914/884510635642216499/1111321692703305729

There is a tab character in the appId of Fallout New Vegas: Honest Hearts DLC, this breaks metadata storage on Windows as they can't handle tabs at the end of the filename (?).

Legendary and Heroic are also affected, but it completed breaks Rare, so dodge it for now pending a fix.